### PR TITLE
Fix signature upload in step 5 to use backend API

### DIFF
--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -240,6 +240,7 @@ export default function ApplyPage() {
       let citizenIdFrontUrl: string | undefined;
       let citizenIdBackUrl: string | undefined;
       let portraitUrl: string | undefined;
+      let personalSignatureUrl: string | undefined;
 
       // Prepare signature file if drawn on canvas
       let signatureFile: File | undefined;
@@ -265,7 +266,7 @@ export default function ApplyPage() {
         if (images.portrait) portraitUrl = await uploadToCloudinary(images.portrait, sig, "image");
         if (signatureFile) {
           const url = await uploadToCloudinary(signatureFile, sig, "image");
-          set("personalSignatureUrl", url);
+          personalSignatureUrl = url;
         }
       }
 
@@ -294,7 +295,7 @@ export default function ApplyPage() {
         loanTermMonths: Number(f.loanTermMonths),
         interestRate: Number(f.interestRate),
         monthlyPaymentDate: Number(f.monthlyPaymentDate),
-        personalSignatureUrl: f.personalSignatureUrl,
+        personalSignatureUrl: personalSignatureUrl || f.personalSignatureUrl,
       };
 
       const headers: Record<string, string> = { "Content-Type": "application/json" };


### PR DESCRIPTION
## Purpose
Update step 5 of the application process to properly handle signature upload by calling the backend API to get signature data and then uploading to Cloudinary, similar to the implementation in step 3. This ensures the personalSignatureUrl is correctly set when creating the application profile.

## Code changes
- Added `personalSignatureUrl` variable declaration to store the uploaded signature URL
- Modified signature file upload logic to assign the Cloudinary URL to `personalSignatureUrl` variable instead of directly setting form data
- Updated the API payload to use the `personalSignatureUrl` variable with fallback to form data value
- Ensures consistent signature handling between step 3 and step 5 workflowsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8180b40662d0499682e46a023f1b9c15/echo-hub)

👀 [Preview Link](https://8180b40662d0499682e46a023f1b9c15-echo-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8180b40662d0499682e46a023f1b9c15</projectId>-->
<!--<branchName>echo-hub</branchName>-->