### PR TITLE
Fix Next.js params type error and add first-loan API

### DIFF
--- a/src/app/api/loans/[id]/route.ts
+++ b/src/app/api/loans/[id]/route.ts
@@ -8,8 +8,8 @@ function buildHeaders(req: NextRequest) {
   return headers;
 }
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  const id = params.id;
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   if (!id) return new Response(JSON.stringify({ message: "Missing id" }), { status: 400 });
   return forwardRaw(req, `/loans/${encodeURIComponent(id)}` , { method: "GET", headers: buildHeaders(req) });
 }

--- a/src/app/api/loans/first-loan/route.ts
+++ b/src/app/api/loans/first-loan/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from "next/server";
+import { forwardRaw } from "@/lib/http";
+
+function buildHeaders(req: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const auth = req.headers.get("authorization");
+  if (auth) headers["authorization"] = auth;
+  return headers;
+}
+
+export async function GET(req: NextRequest) {
+  return forwardRaw(req, "/loans/first-loan", { method: "GET", headers: buildHeaders(req) });
+}

--- a/src/app/profile/personal/page.tsx
+++ b/src/app/profile/personal/page.tsx
@@ -14,9 +14,8 @@ interface LoanData {
   contact1Relationship?: string;
   contact2Phone?: string;
   contact2Relationship?: string;
+  citizenId?: string;
 }
-
-interface LoansApiResponse { data?: LoanData[] }
 
 export default function PersonalInfoPage() {
   const [latestLoan, setLatestLoan] = useState<LoanData | null>(null);
@@ -29,11 +28,10 @@ export default function PersonalInfoPage() {
         const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
         if (!token) return;
         setLoading(true);
-        const res = await fetch("/api/my-loans", { cache: "no-store", headers: { Authorization: `Bearer ${token}` } });
+        const res = await fetch("/api/loans/first-loan", { cache: "no-store", headers: { Authorization: `Bearer ${token}` } });
         if (!res.ok) return;
-        const data: LoanData[] | LoansApiResponse = await res.json().catch(() => null);
-        const arr = Array.isArray(data) ? data : (data?.data || []);
-        if (arr && arr.length > 0) setLatestLoan(arr[0]);
+        const data: LoanData | null = await res.json().catch(() => null);
+        if (data) setLatestLoan(data);
       } catch {
       } finally {
         setLoading(false);
@@ -92,12 +90,17 @@ export default function PersonalInfoPage() {
                 </div>
 
                 <div>
-                  <div className="text-xs text-gray-500">Quê quán</div>
-                  <div className="font-medium text-gray-800">{latestLoan.hometown || '-'}</div>
+                  <div className="text-xs text-gray-500">CCCD</div>
+                  <div className="font-medium text-gray-800">{latestLoan.citizenId || '-'}</div>
                 </div>
                 <div>
                   <div className="text-xs text-gray-500">Nơi ở hiện nay</div>
                   <div className="font-medium text-gray-800">{latestLoan.currentAddress || '-'}</div>
+                </div>
+
+                <div>
+                  <div className="text-xs text-gray-500">Quê quán</div>
+                  <div className="font-medium text-gray-800">{latestLoan.hometown || '-'}</div>
                 </div>
               </div>
 
@@ -116,10 +119,6 @@ export default function PersonalInfoPage() {
                 </div>
               </div>
 
-              <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <button className="w-full px-4 py-3 border border-gray-200 rounded-lg">Chỉnh sửa thông tin</button>
-                <button className="w-full px-4 py-3 bg-white border border-gray-200 rounded-lg text-left" onClick={() => window.alert('Mô phỏng: đổi mật khẩu')}>Đổi mật khẩu</button>
-              </div>
             </div>
 
           </div>


### PR DESCRIPTION
## Purpose
The user needed to resolve a Next.js TypeScript build error related to route parameters and add a new API endpoint to forward calls to the backend's `/api/v1/loans/first-loan` endpoint. The goal was to fix the type compatibility issue and integrate the first loan data retrieval functionality.

## Code changes
- **Fixed Next.js route parameter type error**: Updated `params` type from `{ id: string }` to `Promise<{ id: string }>` and added `await` when accessing params in the loans/[id] route
- **Added new first-loan API endpoint**: Created `/api/loans/first-loan/route.ts` to forward requests to the backend's first loan endpoint
- **Updated personal info page**: Modified the data fetching logic to use the new first-loan endpoint instead of my-loans, simplified response handling, and updated UI to display citizen ID field
- **UI improvements**: Reordered form fields to show CCCD (citizen ID) and removed edit/change password buttonsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/669f69dd15354a6a9727d607301b762d/nova-hub)

👀 [Preview Link](https://669f69dd15354a6a9727d607301b762d-nova-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>669f69dd15354a6a9727d607301b762d</projectId>-->
<!--<branchName>nova-hub</branchName>-->