### PR TITLE
Fix loan amount input field for better mobile editing

### DIFF
--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -182,6 +182,9 @@ export default function ApplyPage() {
     accountHolderName: "",
   });
 
+  const [loanAmountInput, setLoanAmountInput] = useState<string>(String(20_000_000));
+  useEffect(() => { setLoanAmountInput(String(f.loanAmount || "")); }, [f.loanAmount]);
+
   const firstInstallment = useMemo(() => (
     Math.round(calcMonthlyInstallment(f.loanAmount, f.loanTermMonths, f.interestRate))
   ), [f.loanAmount, f.loanTermMonths, f.interestRate]);
@@ -357,9 +360,25 @@ export default function ApplyPage() {
           <h2 className="text-lg font-semibold">Thông tin khoản vay</h2>
           <label className="block text-sm">
             Số tiền vay (20.000.000 - 500.000.000)
-            <input type="number" min={20000000} max={500000000} value={f.loanAmount}
-              onChange={(e)=>set("loanAmount", Math.min(500000000, Math.max(20000000, Number(e.target.value||0))))}
-              className="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="\\d*"
+              value={loanAmountInput}
+              onChange={(e) => {
+                const digits = e.target.value.replace(/\D/g, "");
+                setLoanAmountInput(digits);
+                const num = digits ? Number(digits) : 0;
+                set("loanAmount", num);
+              }}
+              onBlur={() => {
+                const num = f.loanAmount || 0;
+                const clamped = Math.min(500000000, Math.max(20000000, num || 0));
+                set("loanAmount", clamped);
+                setLoanAmountInput(String(clamped));
+              }}
+              className="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
           </label>
           <label className="block text-sm">
             Thời hạn vay


### PR DESCRIPTION
## Purpose
The user reported that the loan amount input field on the apply page was difficult to edit on mobile devices, specifically that the delete/backspace functionality wasn't working properly, making it hard to adjust the loan amount value.

## Code changes
- Changed input type from `number` to `text` with `inputMode="numeric"` and `pattern="\\d*"` for better mobile keyboard support
- Added separate state management for the input field (`loanAmountInput`) to handle text input independently
- Implemented custom `onChange` handler that filters out non-digit characters and updates both the display value and form state
- Added `onBlur` handler to validate and clamp the final value within the allowed range (20,000,000 - 500,000,000)
- Added `useEffect` to sync the input display with the form state when `loanAmount` changes externallyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df68621bc854447d86bee2886ac64574/swoosh-nest)

👀 [Preview Link](https://df68621bc854447d86bee2886ac64574-swoosh-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df68621bc854447d86bee2886ac64574</projectId>-->
<!--<branchName>swoosh-nest</branchName>-->